### PR TITLE
Support actor tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 rvm:
   - 2.0.0
   - jruby

--- a/lib/fridge/access_token.rb
+++ b/lib/fridge/access_token.rb
@@ -15,13 +15,11 @@ module Fridge
                 when Hash then jwt_or_options
                 else {}
                 end
-      [:id, :issuer, :subject, :scope, :expires_at].each do |key|
+
+      [:id, :issuer, :subject, :scope, :expires_at, :actor].each do |key|
         send "#{key}=", options.delete(key)
       end
-      self.actor = nested_hash_keys_to_sym(options.delete(:actor))
-
-      self.attributes = options.reject { |_, v| v.nil? }
-      self.attributes = nested_hash_keys_to_sym(attributes)
+      self.attributes = options
     end
     # rubocop:enable MethodLength
 
@@ -37,15 +35,12 @@ module Fridge
     end
 
     def encode_and_sign
-      h = {
-        id: id,
-        iss: issuer,
-        sub: subject,
-        scope: scope,
-        exp: expires_at.to_i
-      }
-      h[:act] = actor if actor
+      h = {}
+      [:id, :issuer, :subject, :scope, :expires_at, :actor].each do |key|
+        h[key] = send(key)
+      end
       h.merge!(attributes)
+      h = encode_for_jwt(h)
       JWT.encode(h, private_key, algorithm)
     rescue
       raise SerializationError, 'Invalid private key or signing algorithm'
@@ -54,15 +49,7 @@ module Fridge
     # rubocop:disable MethodLength
     def decode_and_verify(jwt)
       hash = JWT.decode(jwt, public_key)
-      base = {
-        id: hash.delete('id'),
-        issuer: hash.delete('iss'),
-        subject: hash.delete('sub'),
-        scope: hash.delete('scope'),
-        expires_at: Time.at(hash.delete('exp')),
-        actor: hash.delete('act')
-      }
-      base.merge(hash)
+      decode_from_jwt(hash)
     rescue JWT::DecodeError
       raise InvalidToken, 'Invalid access token'
     end
@@ -130,9 +117,48 @@ module Fridge
       fail SerializationError, 'No public key configured' unless public_key
     end
 
-    def nested_hash_keys_to_sym(h)
-      return h unless h.is_a? Hash
-      Hash[h.map { |k, v| [k.to_sym, nested_hash_keys_to_sym(v)] }]
+    # Internally, we use "subject" to refer to "sub", and so on. We also
+    # represent some objects (expiry) differently. These functions do the
+    # mapping from Fridge to JWT and vice-versa.
+
+    def encode_for_jwt(hash)
+      out = {
+        id: hash.delete(:id),
+        iss: hash.delete(:issuer),
+        sub: hash.delete(:subject),
+        scope: hash.delete(:scope)
+      }.delete_if { |_, v| v.nil? }
+
+      # Unfortunately, nil.to_i returns 0, which means we can't
+      # easily clean out exp if we include it although it wasn't passed
+      # in like we do for other keys. So, we only include it if it's
+      # actually passed in and non-nil. Either way, we delete the keys.
+      hash.delete(:expires_at).tap { |e| out[:exp] = e.to_i if e }
+      hash.delete(:actor).tap { |a| out[:act] = encode_for_jwt(a) if a }
+
+      # Extra attributes passed through as-is
+      out.merge!(hash)
+
+      out
+    end
+
+    def decode_from_jwt(hash)
+      out = {
+        id: hash.delete('id'),
+        issuer: hash.delete('iss'),
+        subject: hash.delete('sub'),
+        scope: hash.delete('scope')
+      }.delete_if { |_, v| v.nil? }
+
+      hash.delete('exp').tap { |e| out[:expires_at] = Time.at(e) if e }
+      hash.delete('act').tap { |a| out[:actor] = decode_from_jwt(a) if a }
+
+      # Extra attributes
+      hash.delete_if { |_, v| v.nil? }
+      hash = Hash[hash.map { |k, v| [k.to_sym, v] }]
+      out.merge!(hash)
+
+      out
     end
   end
 end

--- a/lib/fridge/rails_helpers.rb
+++ b/lib/fridge/rails_helpers.rb
@@ -15,6 +15,10 @@ module Fridge
       current_token.subject if current_token
     end
 
+    def token_actor
+      current_token.actor if current_token
+    end
+
     def current_token
       return unless bearer_token
       @current_token ||= AccessToken.new(bearer_token).tap do |token|
@@ -29,6 +33,10 @@ module Fridge
 
     def session_subject
       session_token.subject if session_token
+    end
+
+    def session_actor
+      session_token.actor if session_token
     end
 
     def session_token

--- a/lib/fridge/version.rb
+++ b/lib/fridge/version.rb
@@ -1,3 +1,3 @@
 module Fridge
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/fridge/access_token_spec.rb
+++ b/spec/fridge/access_token_spec.rb
@@ -112,12 +112,13 @@ describe Fridge::AccessToken do
     it 'should encode and decode :actor as :act' do
       # The `act` field can recursively encode additional
       # claims, so we check those too.
-      actor = { sub: 'foo', act: { sub: 'bar' } }
+      actor = { subject: 'foo', username: 'test', actor: { subject: 'bar' } }
       subject = described_class.new(options.merge(actor: actor))
 
       # The JWT lib will return everything as strings, so we'll
       # test that, although eventually we'll want to see symbols back.
-      actor_s = { 'sub' => 'foo', 'act' => { 'sub' => 'bar' } }
+      actor_s = { 'sub' => 'foo', 'username' => 'test',
+                  'act' => { 'sub' => 'bar' } }
       hash = JWT.decode(subject.serialize, public_key)
       expect(hash['act']).to eq(actor_s)
 


### PR DESCRIPTION
This adds support for the `act` claim from the [Token Exchange draft RFC][0].

The `act` claim is somewhat recursive, so I've made sure Fridge behave the same way (so that the subject in the an actor claim is still referred to as subject and not `sub`, which might be confusing for unexpecting Fridge users!).

--

cc @fancyremarker 

  [0]:  https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-03