### PR TITLE
Upgrade JWT to 1.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
 rvm:
   - 2.0.0
-  - jruby
+  - 2.1.0
+  - 2.2.0
+  - jruby-9.0.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.0'
+gem 'nokogiri', '~> 1.6.0'
+
 # Specify your gem's dependencies in fridge.gemspec
 gemspec

--- a/fridge.gemspec
+++ b/fridge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'gem_config'
-  spec.add_dependency 'jwt', '~> 0.1.13'
+  spec.add_dependency 'jwt', '~> 1.5.6'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'aptible-tasks'

--- a/lib/fridge.rb
+++ b/lib/fridge.rb
@@ -4,6 +4,7 @@ require 'fridge/version'
 require 'fridge/access_token'
 require 'fridge/serialization_error'
 require 'fridge/invalid_token'
+require 'fridge/expired_token'
 
 require 'fridge/railtie' if defined?(Rails)
 

--- a/lib/fridge/access_token.rb
+++ b/lib/fridge/access_token.rb
@@ -48,8 +48,8 @@ module Fridge
 
     # rubocop:disable MethodLength
     def decode_and_verify(jwt)
-      hash = JWT.decode(jwt, public_key)
-      decode_from_jwt(hash)
+      payload, _header = JWT.decode(jwt, public_key, true, algorithm: algorithm)
+      decode_from_jwt(payload)
     rescue JWT::DecodeError
       raise InvalidToken, 'Invalid access token'
     end

--- a/lib/fridge/access_token.rb
+++ b/lib/fridge/access_token.rb
@@ -50,6 +50,8 @@ module Fridge
     def decode_and_verify(jwt)
       payload, _header = JWT.decode(jwt, public_key, true, algorithm: algorithm)
       decode_from_jwt(payload)
+    rescue JWT::ExpiredSignature
+      raise ExpiredToken, 'Expired access token'
     rescue JWT::DecodeError
       raise InvalidToken, 'Invalid access token'
     end

--- a/lib/fridge/access_token.rb
+++ b/lib/fridge/access_token.rb
@@ -5,7 +5,6 @@ module Fridge
     attr_accessor :id, :issuer, :subject, :scope, :expires_at, :actor,
                   :jwt, :attributes
 
-    # rubocop:disable MethodLength
     def initialize(jwt_or_options = nil)
       options = case jwt_or_options
                 when String
@@ -21,7 +20,6 @@ module Fridge
       end
       self.attributes = options
     end
-    # rubocop:enable MethodLength
 
     def to_s
       serialize
@@ -46,7 +44,6 @@ module Fridge
       raise SerializationError, 'Invalid private key or signing algorithm'
     end
 
-    # rubocop:disable MethodLength
     def decode_and_verify(jwt)
       payload, _header = JWT.decode(jwt, public_key, true, algorithm: algorithm)
       decode_from_jwt(payload)
@@ -55,7 +52,6 @@ module Fridge
     rescue JWT::DecodeError => e
       raise InvalidToken, e.message
     end
-    # rubocop:enable MethodLength
 
     def downgrade
       self.scope = 'read'
@@ -104,19 +100,23 @@ module Fridge
       end
     end
 
+    def respond_to_missing?(method, include_private = false)
+      attributes.key?(method) || super
+    end
+
     def validate_parameters!
       [:subject, :expires_at].each do |attribute|
         next if send(attribute)
-        fail SerializationError, "Missing attribute: #{attribute}"
+        raise SerializationError, "Missing attribute: #{attribute}"
       end
     end
 
     def validate_private_key!
-      fail SerializationError, 'No private key configured' unless private_key
+      raise SerializationError, 'No private key configured' unless private_key
     end
 
     def validate_public_key!
-      fail SerializationError, 'No public key configured' unless public_key
+      raise SerializationError, 'No public key configured' unless public_key
     end
 
     # Internally, we use "subject" to refer to "sub", and so on. We also

--- a/lib/fridge/access_token.rb
+++ b/lib/fridge/access_token.rb
@@ -50,10 +50,10 @@ module Fridge
     def decode_and_verify(jwt)
       payload, _header = JWT.decode(jwt, public_key, true, algorithm: algorithm)
       decode_from_jwt(payload)
-    rescue JWT::ExpiredSignature
-      raise ExpiredToken, 'Expired access token'
-    rescue JWT::DecodeError
-      raise InvalidToken, 'Invalid access token'
+    rescue JWT::ExpiredSignature => e
+      raise ExpiredToken, e.message
+    rescue JWT::DecodeError => e
+      raise InvalidToken, e.message
     end
     # rubocop:enable MethodLength
 

--- a/lib/fridge/expired_token.rb
+++ b/lib/fridge/expired_token.rb
@@ -1,0 +1,4 @@
+module Fridge
+  class ExpiredToken < InvalidToken
+  end
+end

--- a/lib/fridge/rails_helpers.rb
+++ b/lib/fridge/rails_helpers.rb
@@ -62,7 +62,7 @@ module Fridge
       if validator.call(access_token)
         access_token
       else
-        fail InvalidToken, 'Rejected by validator'
+        raise InvalidToken, 'Rejected by validator'
       end
     end
 
@@ -91,7 +91,7 @@ module Fridge
     end
 
     def write_shared_cookie(name, value, options = {})
-      fail 'Can only write string cookie values' unless value.is_a?(String)
+      raise 'Can only write string cookie values' unless value.is_a?(String)
 
       cookies[name] = {
         value: value,
@@ -103,9 +103,9 @@ module Fridge
       cookies[name]
     end
 
-    def fetch_shared_cookie(name, &block)
+    def fetch_shared_cookie(name)
       return read_shared_cookie(name) if read_shared_cookie(name)
-      write_shared_cookie(block.call)
+      write_shared_cookie(yield)
     end
 
     def delete_shared_cookie(name)

--- a/lib/fridge/rails_helpers.rb
+++ b/lib/fridge/rails_helpers.rb
@@ -62,7 +62,7 @@ module Fridge
       if validator.call(access_token)
         access_token
       else
-        fail InvalidToken
+        fail InvalidToken, 'Rejected by validator'
       end
     end
 

--- a/lib/fridge/version.rb
+++ b/lib/fridge/version.rb
@@ -1,3 +1,3 @@
 module Fridge
-  VERSION = '0.3.1'
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/fridge/access_token_spec.rb
+++ b/spec/fridge/access_token_spec.rb
@@ -113,6 +113,8 @@ describe Fridge::AccessToken do
 
       expect(copy.attributes[:foo]).to eq 'bar'
       expect(copy.foo).to eq 'bar'
+      expect(copy.respond_to?(:foo)).to be_truthy
+      expect(copy.respond_to?(:bar)).to be_falsey
     end
 
     it 'should raise an error if required attributes are missing' do

--- a/spec/fridge/access_token_spec.rb
+++ b/spec/fridge/access_token_spec.rb
@@ -31,6 +31,14 @@ describe Fridge::AccessToken do
       expect { described_class.new(jwt) }.to raise_error Fridge::InvalidToken
     end
 
+    it 'should raise an error on an expired JWT' do
+      jwt = JWT.encode(
+        { id: 'foobar', exp: Time.now.to_i - 10 },
+        private_key, 'RS512'
+      )
+      expect { described_class.new(jwt) }.to raise_error(Fridge::ExpiredToken)
+    end
+
     # http://bit.ly/jwt-none-vulnerability
     it 'should raise an error with { "alg": "none" }' do
       jwt = "#{Base64.encode64({ typ: 'JWT', alg: 'none' }.to_json).chomp}." \

--- a/spec/fridge/rails_helpers_spec.rb
+++ b/spec/fridge/rails_helpers_spec.rb
@@ -139,7 +139,7 @@ describe Controller, type: :controller do
       end
 
       it 'should return false if the token validator fails' do
-        Fridge.configuration.validator = ->(_) { fail 'Foobar' }
+        Fridge.configuration.validator = ->(_) { raise 'Foobar' }
         expect(controller.validate_token(access_token)).to be false
       end
 


### PR DESCRIPTION
The two major API changes here are:

- We can specify the algorithm to use when decoding (which is important
  from a security perspective, although it hasn't affected us).
- `JWT.decode` now returns `[payload, header]` as opposed to just the
  payload.

---

cc @fancyremarker 