### PR TITLE
Restrict cookies to only the auth domain

### DIFF
--- a/lib/fridge/rails_helpers.rb
+++ b/lib/fridge/rails_helpers.rb
@@ -88,7 +88,7 @@ module Fridge
     end
 
     def clear_session_cookie
-      cookies.delete fridge_cookie_name, domain: :all
+      cookies.delete fridge_cookie_name, domain: auth_domain
       nil
     end
 
@@ -121,8 +121,14 @@ module Fridge
 
     def fridge_cookie_options
       secure = !Rails.env.development?
-      options = { domain: :all, secure: secure, httponly: true }
+      options = { domain: auth_domain, secure: secure, httponly: true }
       options.merge(Fridge.configuration.cookie_options)
+    end
+
+    def auth_domain
+      Aptible::Auth.configuration.root_url.sub(%r{^https?://}, '')
+    rescue StandardError
+      'auth.aptible.com'
     end
   end
 end

--- a/lib/fridge/version.rb
+++ b/lib/fridge/version.rb
@@ -1,3 +1,3 @@
 module Fridge
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end

--- a/spec/fridge/rails_helpers_spec.rb
+++ b/spec/fridge/rails_helpers_spec.rb
@@ -104,7 +104,8 @@ describe Fridge::RailsHelpers do
     it 'should delete all cookies on error' do
       cookies[:fridge_session] = 'foobar'
       controller.session_token
-      expect(cookies.deleted?(:fridge_session, domain: :all)).to be true
+      expect(cookies.deleted?(:fridge_session, domain: 'auth.aptible.com'))
+        .to be true
     end
 
     it 'should return nil on error' do
@@ -211,7 +212,7 @@ describe Fridge::RailsHelpers do
     it 'are configurable' do
       Fridge.configuration.cookie_options = { foobar: true }
       options = controller.fridge_cookie_options
-      expect(options[:domain]).to eq :all
+      expect(options[:domain]).to eq 'auth.aptible.com'
       expect(options[:foobar]).to eq true
     end
   end


### PR DESCRIPTION
See: https://aptible.slack.com/archives/C0D7LB6LF/p1611332660036200

The Fridge cookie is used to store a read-only ("sessionized") token. It
can then be used to GET the `current_token` endpoint on auth to get a
"manage" scoped token.

We are restricting the token to the auth subdomain only so that our
users' browsers will not send it to ALL aptible.com subdomains, as it
currently does. We are now hosting some aptible subdomains with
third-party vendors as well as in customer stacks for Crazylegs. This
change will prevent those services from getting access to Aptible tokens
through those cookies.

---

Pulled into auth in: https://github.com/aptible/auth-api/pull/417
