### PR TITLE
Allow for domains with ports specified if used on localhost

### DIFF
--- a/lib/fridge/rails_helpers.rb
+++ b/lib/fridge/rails_helpers.rb
@@ -126,7 +126,11 @@ module Fridge
     end
 
     def auth_domain
-      Aptible::Auth.configuration.root_url.sub(%r{^https?://}, '')
+      domain = URI.parse(Aptible::Auth.configuration.root_url).host
+
+      # On localhost we fall back to the default setting b/c browsers won't set
+      # cookies if localhost is named
+      domain == 'localhost' ? :all : domain
     rescue StandardError
       'auth.aptible.com'
     end

--- a/spec/fridge/rails_helpers_spec.rb
+++ b/spec/fridge/rails_helpers_spec.rb
@@ -215,5 +215,25 @@ describe Fridge::RailsHelpers do
       expect(options[:domain]).to eq 'auth.aptible.com'
       expect(options[:foobar]).to eq true
     end
+
+    it 'restricts cookies to the specific subdomain' do
+      auth = class_double('Aptible::Auth').as_stubbed_const
+      allow(auth).to receive_message_chain(:configuration, :root_url) do
+        'https://auth-bob.aptible-sandbox.com'
+      end
+
+      options = controller.fridge_cookie_options
+      expect(options[:domain]).to eq 'auth-bob.aptible-sandbox.com'
+    end
+
+    it 'handles local development using defaults' do
+      auth = class_double('Aptible::Auth').as_stubbed_const
+      allow(auth).to receive_message_chain(:configuration, :root_url) do
+        'https://localhost:4000'
+      end
+
+      options = controller.fridge_cookie_options
+      expect(options[:domain]).to eq :all
+    end
   end
 end


### PR DESCRIPTION
Right now if auth-api is run off of localhost, then it will try to set
that specific domain, which will fail because most browsers will ignore
it.

Previously we left it as the default domain, which browsers allow for
localhost cookies. I don't understand WHY, but that's my best googling
of the problem that Maryam encountered.

So now we strip off the port number to allow it be specified as well as
special casing handling of localhost. This should let local development
sessions work "correctly" but the behavior will be slightly different
than in production where the cookie set will NOT work for our multiple
services.

If folks need that behavior, they should ensure the the various APIs are
on different subdomains (e.g,. via /etc/hosts, docker-compose
networking, etc.)