### PR TITLE
Update JWT to 2.3, fix specs

### DIFF
--- a/fridge.gemspec
+++ b/fridge.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'gem_config'
-  spec.add_dependency 'jwt', '~> 1.5.6'
+  spec.add_dependency 'jwt', '~> 2.3.0'
 
   spec.add_development_dependency 'aptible-tasks'
   spec.add_development_dependency 'pry'

--- a/lib/fridge/version.rb
+++ b/lib/fridge/version.rb
@@ -1,3 +1,3 @@
 module Fridge
-  VERSION = '0.4.5'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/fridge/access_token_spec.rb
+++ b/spec/fridge/access_token_spec.rb
@@ -79,21 +79,22 @@ describe Fridge::AccessToken do
     end
 
     it 'should be verifiable with the application public key' do
-      expect { JWT.decode(subject.serialize, public_key) }.not_to raise_error
+      expect { JWT.decode(subject.serialize, public_key, true, algorithm: 'RS512') }
+        .not_to raise_error
     end
 
     it 'should be tamper-resistant' do
       header, _, signature = subject.serialize.split('.')
-      tampered_claim = JWT.base64url_encode({ foo: 'bar' }.to_json)
+      tampered_claim = JWT::Base64.url_encode({ foo: 'bar' }.to_json)
       tampered_token = [header, tampered_claim, signature].join('.')
 
       expect do
-        JWT.decode(tampered_token, public_key)
+        JWT.decode(tampered_token, public_key, true, algorithm: 'RS512')
       end.to raise_error JWT::DecodeError
     end
 
     it 'should represent :exp in seconds since the epoch' do
-      hash, = JWT.decode(subject.serialize, public_key)
+      hash, = JWT.decode(subject.serialize, public_key, true, algorithm: 'RS512')
       expect(hash['exp']).to be_a Integer
     end
 
@@ -133,7 +134,7 @@ describe Fridge::AccessToken do
       # test that, although eventually we'll want to see symbols back.
       actor_s = { 'sub' => 'foo', 'username' => 'test',
                   'act' => { 'sub' => 'bar' } }
-      hash, = JWT.decode(subject.serialize, public_key)
+      hash, = JWT.decode(subject.serialize, public_key, true, algorithm: 'RS512')
       expect(hash['act']).to eq(actor_s)
 
       # Now, check that we properly get symbols back


### PR DESCRIPTION
Version 2.3 of JWT chosen as a good middle step before continuing updates

Main change from 1.x to 2.x was `JWT.decode` now needing an algorithm list we want to use, as it defaults to HS256 otherwise - [we're already doing this in the main code](https://github.com/aptible/fridge/blob/master/lib/fridge/access_token.rb#L49), so only needed to update specs